### PR TITLE
Automatically add pre-commit hook for spotlessCheck

### DIFF
--- a/.scripts/pre-commit
+++ b/.scripts/pre-commit
@@ -1,0 +1,2 @@
+#!/bin/bash
+./gradlew spotlessCheck

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,3 +20,13 @@ spotless {
     ktlint()
   }
 }
+
+val installGitHook by tasks.registering(Copy::class) {
+  from(file("${rootProject.rootDir}/.scripts/pre-commit"))
+  into(file("${rootProject.rootDir}/.git/hooks"))
+  fileMode = 775
+}
+
+tasks.named("build") {
+  dependsOn(installGitHook)
+}


### PR DESCRIPTION
As a software developer,
I want a pre-commit hook to automatically be added for running spotlessCheck,
So that I can ensure code formatting standards are adhered to before any code is committed to the repository.

**Acceptance Criteria:**


1. The pre-commit hook should trigger the spotlessCheck task before allowing the commit to proceed.
2. If the spotlessCheck task fails, the commit should be blocked, and a descriptive error message should be shown indicating the formatting issues.
3. If the spotlessCheck task passes, the commit should proceed as normal.
4. There should be documentation provided on how to manually set up, disable, or modify the pre-commit hook for spotlessCheck.
5. The functionality should work across different operating systems and should be compatible with the version control system in use.