### PR TITLE
#137 Fix JSON parsing for null imdb value

### DIFF
--- a/data/network/src/main/java/io/filmtime/data/network/trakt/TraktMovieIDLookupResponse.kt
+++ b/data/network/src/main/java/io/filmtime/data/network/trakt/TraktMovieIDLookupResponse.kt
@@ -21,6 +21,6 @@ data class Movie(
 data class IDS(
   val trakt: Int,
   val slug: String,
-  val imdb: String,
+  val imdb: String? = null,
   val tmdb: Int,
 )


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly.

Take a look at the [contributing guidelines](https://github.com/moallemi/Film-Time/blob/dev/CONTRIBUTING.md) for this project.

### Description
This PR fixes the JSON parsing error caused by null values in the 'imdb' field (e.g., when viewing movie details like "If" (2013)). The change makes the 'imdb' field nullable (`String? = null`) in the data model to handle null inputs gracefully without crashing.

Since `ids.imdb` is only used once in the codebase and that usage already supports null values, no additional changes were necessary.

Steps to test:
1. Run the app on Android.
2. Search "se"
3. View details of a movie with null imdb (e.g., "If").
4. Confirm the data loads without parsing errors.

### Checklist
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the linter (code style) passes
- [x] Appropriate docs were updated (if necessary)

Fixes #137 